### PR TITLE
Require space after variable colon only when single line

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     "scss/double-slash-comment-empty-line-before": ["always", {
       "except": ["first-nested"]
     }],
-    "scss/dollar-variable-colon-space-after": "always",
+    "scss/dollar-variable-colon-space-after": "always-single-line",
     "scss/dollar-variable-colon-space-before": "never",
     "scss/at-import-no-partial-leading-underscore": true
   }


### PR DESCRIPTION
Fixes #2 